### PR TITLE
chore: deleted_at 변경으로 인한 충돌 해결

### DIFF
--- a/src/main/java/com/fifteen/auction/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/fifteen/auction/domain/product/repository/ProductRepository.java
@@ -1,10 +1,6 @@
 package com.fifteen.auction.domain.product.repository;
 
 import com.fifteen.auction.domain.product.entity.Product;
-import com.fifteen.auction.domain.product.entity.ProductCategory;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,16 +17,16 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // (추후 필요 시 보류)
     // Page<Product> findAllBySellerIdAndDeletedAtIsNull(Long sellerId, Pageable pageable);
     // List<Product> findByCategoryAndDeletedAtIsNull(ProductCategory category);
-  
-    Page<Product> findAllBySellerIdAndDeletedFalse(Long sellerId, Pageable pageable);
 
-    List<Product> findByCategoryAndDeletedFalse(ProductCategory category);
+//    Page<Product> findAllBySellerIdAndDeletedFalse(Long sellerId, Pageable pageable);
+//
+//    List<Product> findByCategoryAndDeletedFalse(ProductCategory category);
+//
+//    Optional<Product> findByIdAndDeletedFalse(Long id);
+//
+//    Page<Product> findAllByDeletedFalse(Pageable pageable);
 
-    Optional<Product> findByIdAndDeletedFalse(Long id);
-
-    Page<Product> findAllByDeletedFalse(Pageable pageable);
-
-    @Query("select p from Product p join fetch p.seller where p.id = :productId and p.deleted = false")
+    @Query("select p from Product p join fetch p.seller where p.id = :productId and p.deletedAt != null ")
     Optional<Product> findByIdWithSeller(@Param("productId") Long id);
-  
+
 }


### PR DESCRIPTION
Product에서 deleted field가 deleted_at으로 대체되면서 Repository에 있는 named 메서드들이 제대로 동작하지 않아 주석처리했습니다.

현재 빌드되는 것으로 확인됩니다.