### PR TITLE
Auction 도메인 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'

--- a/src/main/java/com/fifteen/auction/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/controller/AuctionController.java
@@ -42,14 +42,8 @@ public class AuctionController {
     @GetMapping("/v1/auctions")
     ResponseEntity<Response<List<AuctionListItem>>> findAll(@ModelAttribute PageCond cond) {
         Page<AuctionListItem> result = auctionService.findAll(cond);
-        PageInfo pageInfo = PageInfo.builder()
-                .pageNum(result.getNumber())
-                .pageSize(result.getSize())
-                .totalElement(result.getTotalElements())
-                .totalPage(result.getTotalPages())
-                .build();
 
-        return ResponseEntity.ok(Response.of(result.getContent(), pageInfo));
+        return ResponseEntity.ok(Response.of(result.getContent(), PageInfo.fromPage(result)));
     }
 
     @GetMapping("/v1/auctions/{auctionSeq}")

--- a/src/main/java/com/fifteen/auction/domain/auction/controller/BidController.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/controller/BidController.java
@@ -48,12 +48,6 @@ public class BidController {
             @ModelAttribute PageCond pageCond
     ) {
         Page<BidHistoryInfo> result = bidService.bidHistoriesInProgress(auctionSeq, pageCond);
-        PageInfo pageInfo = PageInfo.builder()
-                .pageNum(result.getNumber())
-                .pageSize(result.getSize())
-                .totalElement(result.getTotalElements())
-                .totalPage(result.getTotalPages())
-                .build();
-        return ResponseEntity.ok(Response.of(result.getContent(), pageInfo));
+        return ResponseEntity.ok(Response.of(result.getContent(), PageInfo.fromPage(result)));
     }
 }

--- a/src/main/java/com/fifteen/auction/domain/auction/dto/request/AuctionCreateRequest.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/dto/request/AuctionCreateRequest.java
@@ -3,11 +3,16 @@ package com.fifteen.auction.domain.auction.dto.request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class AuctionCreateRequest {
     @NotNull
     private Long productId;

--- a/src/main/java/com/fifteen/auction/domain/auction/dto/request/AuctionUpdateRequest.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/dto/request/AuctionUpdateRequest.java
@@ -2,11 +2,16 @@ package com.fifteen.auction.domain.auction.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class AuctionUpdateRequest {
     @Min(0)
     private Long startPrice;

--- a/src/main/java/com/fifteen/auction/domain/auction/dto/request/BidRequest.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/dto/request/BidRequest.java
@@ -2,9 +2,14 @@ package com.fifteen.auction.domain.auction.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class BidRequest {
 
     @Min(0) @NotNull

--- a/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
@@ -136,6 +136,7 @@ public class Auction extends BaseEntity {
     public void extendExpireTime(LocalDateTime bidAt) {
         if (this.isAutoExtensible && is1minBeforeExpiration(bidAt)) {
             this.expiresAt = this.expiresAt.plusMinutes(EXTENSION_TIME);
+            this.isAutoExtensible = false; // TODO(yeonic) : 동시성 문제 해결 필요할수도
         }
     }
 

--- a/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
@@ -155,9 +155,10 @@ public class Auction extends BaseEntity {
         this.expiresAt = useIfNotNull(expiresAt, this.expiresAt);
     }
 
+
     private boolean is1minBeforeExpiration(LocalDateTime bidAt) {
         Duration between = Duration.between(bidAt, this.expiresAt).abs();
-        return between.toMinutes() == 0 && between.getSeconds() <= 60;
+        return between.toMinutes() == 0 && between.getSeconds() < 60;
     }
 
     private <T> T useIfNotNull(T input, T existing) {

--- a/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/entity/Auction.java
@@ -142,7 +142,7 @@ public class Auction extends BaseEntity {
 
     public void updateInfo(
             Long startPrice, Long buyNowPrice, Integer bidUnit,
-            Boolean isBuyNowSet, Boolean isAutoExtensible
+            Boolean isBuyNowSet, Boolean isAutoExtensible, LocalDateTime expiresAt
     ) {
         if (this.status != AuctionStatus.PENDING) {
             throw new ClientException(ErrorCode.AUCTION_ALREADY_OPEN);
@@ -152,6 +152,7 @@ public class Auction extends BaseEntity {
         this.bidUnit = useIfNotNull(bidUnit, this.bidUnit);
         this.isBuyNowSet = useIfNotNull(isBuyNowSet, this.isBuyNowSet);
         this.isAutoExtensible = useIfNotNull(isAutoExtensible, this.isAutoExtensible);
+        this.expiresAt = useIfNotNull(expiresAt, this.expiresAt);
     }
 
     private boolean is1minBeforeExpiration(LocalDateTime bidAt) {

--- a/src/main/java/com/fifteen/auction/domain/auction/repository/auction/AuctionRepository.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/repository/auction/AuctionRepository.java
@@ -16,14 +16,15 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, Auction
             """)
     Optional<Auction> findOneBySeqAndSellerId(@Param("auctionSeq") String auctionSeq, @Param("sellerId") Long sellerId);
 
-    @Query("SELECT a FROM Auction a JOIN FETCH a.product p JOIN FETCH p.seller s WHERE a.auctionSeq = :auctionSeq")
+    @Query("SELECT a FROM Auction a JOIN FETCH a.product p JOIN FETCH p.seller s" +
+            " WHERE a.auctionSeq = :auctionSeq AND a.status = 'OPEN'")
     Optional<Auction> findOpenOneBySeqWithSeller(@Param("auctionSeq") String auctionSeq);
 
     // Auction과 Tag를 연결하는 AuctionTag를 통해 경매와 태그를 찾음
     @Query("""
-    SELECT DISTINCT a FROM Auction a
-    JOIN a.tags at
-    WHERE at.tag.id IN :tagIds AND a.status = 'OPEN'
-    """)
+            SELECT DISTINCT a FROM Auction a
+            JOIN a.tags at
+            WHERE at.tag.id IN :tagIds AND a.status = 'OPEN'
+            """)
     List<Auction> findOpenAuctionsByTagIds(@Param("tagIds") List<Long> tagIds);
 }

--- a/src/main/java/com/fifteen/auction/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/service/AuctionService.java
@@ -10,6 +10,7 @@ import com.fifteen.auction.domain.auction.entity.Auction;
 import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
 import com.fifteen.auction.domain.auction.repository.bid.BidRepository;
 import com.fifteen.auction.domain.auction.util.AuctionSeqGenerator;
+import com.fifteen.auction.domain.auction.util.ClockHolder;
 import com.fifteen.auction.domain.product.dto.response.MarketPriceFullResponse;
 import com.fifteen.auction.domain.product.entity.Product;
 import com.fifteen.auction.domain.product.repository.ProductRepository;
@@ -27,7 +28,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static com.fifteen.auction.domain.user.enums.UserRole.Authority.ROLE_USER;
 
@@ -42,6 +42,7 @@ public class AuctionService {
     private final AuctionCacheService auctionCacheService;
 
     private final AuctionSeqGenerator auctionSeqGenerator;
+    private final ClockHolder clockHolder;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Secured(ROLE_USER)
@@ -70,7 +71,7 @@ public class AuctionService {
         Auction auction = auctionRepository
                 .findOneBySeqAndSellerId(auctionSeq, sellerId)
                 .orElseThrow(() -> new ClientException(ErrorCode.AUCTION_NOT_FOUND));
-        auction.cancel(LocalDateTime.now());
+        auction.cancel(clockHolder.now());
     }
 
     @Secured(ROLE_USER)
@@ -99,7 +100,8 @@ public class AuctionService {
                 req.getBuyNowPrice(),
                 req.getBidUnit(),
                 req.getIsBuyNowSet(),
-                req.getIsAutoExtensible()
+                req.getIsAutoExtensible(),
+                req.getExpiresAt()
         );
     }
 

--- a/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
@@ -12,7 +12,6 @@ import com.fifteen.auction.domain.auction.util.ClockHolder;
 import com.fifteen.auction.global.dto.PageCond;
 import com.fifteen.auction.global.dto.error.ErrorCode;
 import com.fifteen.auction.global.dto.exception.ClientException;
-import io.micrometer.core.instrument.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -37,7 +36,6 @@ public class BidService {
 
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
-    private final Clock clock;
 
     @Secured(ROLE_USER)
     @Transactional

--- a/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
@@ -8,9 +8,11 @@ import com.fifteen.auction.domain.auction.entity.Auction;
 import com.fifteen.auction.domain.auction.entity.Bid;
 import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
 import com.fifteen.auction.domain.auction.repository.bid.BidRepository;
+import com.fifteen.auction.domain.auction.util.ClockHolder;
 import com.fifteen.auction.global.dto.PageCond;
 import com.fifteen.auction.global.dto.error.ErrorCode;
 import com.fifteen.auction.global.dto.exception.ClientException;
+import io.micrometer.core.instrument.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -29,11 +31,13 @@ import static com.fifteen.auction.domain.user.enums.UserRole.Authority.ROLE_USER
 public class BidService {
 
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ClockHolder clockHolder;
 
     private final AuctionCacheService auctionCacheService;
 
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
+    private final Clock clock;
 
     @Secured(ROLE_USER)
     @Transactional
@@ -42,7 +46,7 @@ public class BidService {
         Auction findAuction = auctionRepository.findOpenOneBySeqWithSeller(auctionSeq)
                 .orElseThrow(() -> new ClientException(ErrorCode.AUCTION_NOT_FOUND));
 
-        LocalDateTime bidAt = LocalDateTime.now();
+        LocalDateTime bidAt = clockHolder.now();
 
         if (isInvalidBid(userId, findAuction, bidAt)) {
             throw new ClientException(ErrorCode.INVALID_BID_REQUEST);
@@ -65,7 +69,11 @@ public class BidService {
         Auction findAuction = auctionRepository.findOpenOneBySeqWithSeller(auctionSeq)
                 .orElseThrow(() -> new ClientException(ErrorCode.AUCTION_NOT_FOUND));
 
-        LocalDateTime buyAt = LocalDateTime.now();
+        LocalDateTime buyAt = clockHolder.now();
+
+        if (!findAuction.isBuyNowSet()) {
+            throw new ClientException(ErrorCode.CANNOT_BUY_NOW);
+        }
 
         if (isInvalidBid(userId, findAuction, buyAt)) {
             throw new ClientException(ErrorCode.INVALID_BUY_NOW_REQUEST);

--- a/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/service/BidService.java
@@ -5,7 +5,6 @@ import com.fifteen.auction.domain.auction.dto.event.BuyNowEvent;
 import com.fifteen.auction.domain.auction.dto.request.BidRequest;
 import com.fifteen.auction.domain.auction.dto.response.BidHistoryInfo;
 import com.fifteen.auction.domain.auction.entity.Auction;
-import com.fifteen.auction.domain.auction.entity.AuctionStatus;
 import com.fifteen.auction.domain.auction.entity.Bid;
 import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
 import com.fifteen.auction.domain.auction.repository.bid.BidRepository;
@@ -40,7 +39,6 @@ public class BidService {
     @Transactional
     public void bid(String auctionSeq, Long userId, BidRequest req) {
 
-        // 본인이 생성한 경매이거나 마감된 경매인지 체크
         Auction findAuction = auctionRepository.findOpenOneBySeqWithSeller(auctionSeq)
                 .orElseThrow(() -> new ClientException(ErrorCode.AUCTION_NOT_FOUND));
 
@@ -89,7 +87,6 @@ public class BidService {
 
     private boolean isInvalidBid(Long userId, Auction findAuction, LocalDateTime bidAt) {
         return userId.equals(findAuction.getProduct().getSeller().getId())
-                || findAuction.getStatus() != AuctionStatus.OPEN
                 || bidAt.isAfter(findAuction.getExpiresAt());
     }
 }

--- a/src/main/java/com/fifteen/auction/domain/auction/service/ScheduledAuctionService.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/service/ScheduledAuctionService.java
@@ -35,7 +35,7 @@ public class ScheduledAuctionService {
         // 스케줄러 세팅
         Instant reservedTime = event.getExpiresAt().atZone(ZoneId.systemDefault()).toInstant();
         ScheduledFuture<?> scheduled = taskScheduler.schedule(
-                sendExpirationMessage(event.getAuctionId(), event.getAuctionSeq(), event.getStartPrice()),
+                () -> handleExpiration(event.getAuctionId(), event.getAuctionSeq(), event.getStartPrice()),
                 reservedTime
         );
         scheduledWork.put(event.getAuctionSeq(), scheduled);
@@ -44,7 +44,12 @@ public class ScheduledAuctionService {
     @EventListener(BuyNowEvent.class)
     public void handleBuyNow(BuyNowEvent event) {
         cancelReservedNoti(event);
+        processBuyNowMessaging(event);
 
+        log.info("sent buy now message for auction: {}", event.getAuctionSeq());
+    }
+
+    public void processBuyNowMessaging(BuyNowEvent event) {
         // 낙찰자 메시지 전송
         sendWinnerMessage(event.getAuctionSeq(), event.getWinnerId());
 
@@ -53,43 +58,39 @@ public class ScheduledAuctionService {
         sendParticipantsMessage(event.getAuctionSeq(), participants);
 
         auctionCacheService.flushTopBidCache(event.getAuctionSeq());
+    }
 
-        log.info("sent buy now message for auction: {}", event.getAuctionSeq());
+    public void handleExpiration(Long auctionId, String auctionSeq, Long startPrice) {
+        // 현재 가격 가져오기
+        Long currentPrice = auctionCacheService.findCurrentPrice(auctionSeq);
+
+        // 유찰 처리
+        if (currentPrice.equals(startPrice)) {
+            auctionService.miscarry(auctionId);
+            return;
+        }
+
+        // 입찰 이력 긁어오기
+        List<Long> participants = auctionCacheService.findParticipants(auctionSeq);
+
+        // 낙찰자 처리
+        Long winnerId = participants.get(0);
+        auctionService.processWinning(auctionSeq, winnerId, currentPrice);
+        sendWinnerMessage(auctionSeq, winnerId);
+
+        // 이외 사람들 처리
+        sendParticipantsMessage(auctionSeq, participants.subList(1, participants.size()));
+
+        auctionCacheService.flushTopBidCache(auctionSeq);
+
+        scheduledWork.remove(auctionSeq);
+
+        log.info("sent expiration message for auction: {}", auctionSeq);
     }
 
     private void cancelReservedNoti(BuyNowEvent event) {
         scheduledWork.get(event.getAuctionSeq()).cancel(true);
         scheduledWork.remove(event.getAuctionSeq());
-    }
-
-    private Runnable sendExpirationMessage(Long auctionId, String auctionSeq, Long startPrice) {
-        return () -> {
-            // 현재 가격 가져오기
-            Long currentPrice = auctionCacheService.findCurrentPrice(auctionSeq);
-
-            // 유찰 처리
-            if (currentPrice.equals(startPrice)) {
-                auctionService.miscarry(auctionId);
-                return;
-            }
-
-            // 입찰 이력 긁어오기
-            List<Long> participants = auctionCacheService.findParticipants(auctionSeq);
-
-            // 낙찰자 처리
-            Long winnerId = participants.get(0);
-            auctionService.processWinning(auctionSeq, winnerId, currentPrice);
-            sendWinnerMessage(auctionSeq, winnerId);
-
-            // 이외 사람들 처리
-            sendParticipantsMessage(auctionSeq, participants.subList(1, participants.size()));
-
-            auctionCacheService.flushTopBidCache(auctionSeq);
-
-            scheduledWork.remove(auctionSeq);
-
-            log.info("sent expiration message for auction: {}", auctionSeq);
-        };
     }
 
     private void sendParticipantsMessage(String auctionSeq, List<Long> participants) {

--- a/src/main/java/com/fifteen/auction/domain/auction/util/ClockHolder.java
+++ b/src/main/java/com/fifteen/auction/domain/auction/util/ClockHolder.java
@@ -1,0 +1,12 @@
+package com.fifteen.auction.domain.auction.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ClockHolder {
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fifteen/auction/global/dto/error/ErrorCode.java
+++ b/src/main/java/com/fifteen/auction/global/dto/error/ErrorCode.java
@@ -27,11 +27,11 @@ public enum ErrorCode {
     PAYMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT-5", "결제 승인 요청을 실패했습니다."),
 
     // Settlement Exceptions
-    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"SETTLEMENT-1", "정산할 데이터가 존재하지 않습니다"),
-    SETTLEMENT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"SETTLEMENT-2", "정산 데이터 출력 중 오류가 생겼습니다."),
+    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT-1", "정산할 데이터가 존재하지 않습니다"),
+    SETTLEMENT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SETTLEMENT-2", "정산 데이터 출력 중 오류가 생겼습니다."),
 
     // Charge Exceptions
-    CHARGE_NOT_FOUND(HttpStatus.NOT_FOUND,"CHARGE-1", "해당 수수료가 존재하지 않습니다."),
+    CHARGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHARGE-1", "해당 수수료가 존재하지 않습니다."),
 
     //User 에러 코드
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-1", "해당 유저를 찾을 수 없습니다."),
@@ -59,6 +59,7 @@ public enum ErrorCode {
     CLOSE_NOT_PENDING(HttpStatus.BAD_REQUEST, "AUCTION-8", "공개 전 상태의 경매만 등록 취소가 가능합니다."),
     AUCTION_NOT_OPEN(HttpStatus.BAD_REQUEST, "AUCTION-9", "경매가 진행중일 때만 요청할 수 있는 작업입니다."),
     FINALIZE_ALREADY_DONE(HttpStatus.BAD_REQUEST, "AUCTION-10", "이미 마감 처리 된 경매입니다."),
+    CANNOT_BUY_NOW(HttpStatus.BAD_REQUEST, "AUCTION-11", "즉시 구매가 불가능한 경매입니다."),
 
     // Product Custom Exception
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT-1", "존재하지 않는 상품입니다."),
@@ -94,7 +95,7 @@ public enum ErrorCode {
     INBOX_MSG_NOT_FOUND(HttpStatus.NOT_FOUND, "MSG-1", "해당 알림이 존재하지 않습니다."),
 
     // Chat Exception
-    INVALID_CHAT_REQUEST(HttpStatus.BAD_REQUEST,"CHAT-1","본인과의 채팅은 불가능합니다."),
+    INVALID_CHAT_REQUEST(HttpStatus.BAD_REQUEST, "CHAT-1", "본인과의 채팅은 불가능합니다."),
 
     // Uncaught Exceptions
     EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "EXCEPTION", "알 수 없는 에러입니다.");

--- a/src/test/java/com/fifteen/auction/domain/auction/AuctionEventTest.java
+++ b/src/test/java/com/fifteen/auction/domain/auction/AuctionEventTest.java
@@ -1,34 +1,49 @@
 package com.fifteen.auction.domain.auction;
 
 import com.fifteen.auction.domain.auction.dto.event.BidProcessEvent;
+import com.fifteen.auction.domain.auction.dto.event.BuyNowEvent;
 import com.fifteen.auction.domain.auction.entity.Auction;
 import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
 import com.fifteen.auction.domain.auction.service.AuctionCacheService;
+import com.fifteen.auction.domain.auction.service.AuctionService;
 import com.fifteen.auction.domain.auction.service.BidWorkerService;
+import com.fifteen.auction.domain.auction.service.ScheduledAuctionService;
+import com.fifteen.auction.domain.inbox.dto.CreateMessageRequest;
+import com.fifteen.auction.domain.inbox.service.InboxService;
+import com.fifteen.auction.global.dto.error.ErrorCode;
+import com.fifteen.auction.global.dto.exception.ClientException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
-import static com.fifteen.auction.fixtures.AuctionFixture.withIsAutoExtensible;
+import static com.fifteen.auction.domain.auction.entity.AuctionStatus.DONE;
+import static com.fifteen.auction.domain.auction.entity.AuctionStatus.MISCARRY;
+import static com.fifteen.auction.fixtures.AuctionFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AuctionEventTest {
 
+    public static final String ERROR_CODE_ENUM_NAME = "errorCode";
+
     @Nested
     class 입찰_이벤트 {
-
         @Mock AuctionRepository auctionRepository;
         @Mock AuctionCacheService auctionCacheService;
 
@@ -116,5 +131,194 @@ public class AuctionEventTest {
                     .addNewHighPrice(eq("seq"), eq(2L), eq(2000L));
         }
 
+    }
+
+    @Nested
+    class 종료된_경매 {
+        AuctionRepository auctionRepository;
+
+        AuctionCacheService auctionCacheService;
+        InboxService inboxService;
+
+        ScheduledAuctionService scheduledAuctionService;
+
+        public 종료된_경매() {
+            auctionRepository = mock(AuctionRepository.class);
+            auctionCacheService = mock(AuctionCacheService.class);
+
+            inboxService = mock(InboxService.class);
+            scheduledAuctionService = new ScheduledAuctionService(
+                    mock(TaskScheduler.class),
+                    auctionCacheService,
+                    spy(new AuctionService(
+                            auctionRepository,
+                            null, null, null,
+                            auctionCacheService,
+                            null, null, null
+                    )),
+                    inboxService
+            );
+        }
+
+        @Test
+        void 종료된_경매_가_유찰_처리_될_때_그_경매는_공개_상태여야만_한다() {
+            // given
+            Auction auction = withStartPrice(1L, 1L, "seq", 8000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+
+            given(auctionCacheService.findCurrentPrice(anyString())).willReturn(8000L);
+            given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
+
+            // when & then
+            assertThatThrownBy(() -> scheduledAuctionService.handleExpiration(1L, "seq", 8000L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.AUCTION_NOT_OPEN);
+        }
+
+        @Test
+        void 종료된_경매_가_유찰_처리_되면_유찰_상태가_되고_만료_시각이_종료_시각이_된다() {
+            // given
+            Auction auction = withStartPrice(1L, 1L, "seq", 8000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+
+            given(auctionCacheService.findCurrentPrice(anyString())).willReturn(8000L);
+            given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
+
+            // when
+            scheduledAuctionService.handleExpiration(1L, "seq", 8000L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getStatus()).isEqualTo(MISCARRY);
+                softly.assertThat(auction.getDoneAt()).isEqualTo(auction.getExpiresAt());
+            });
+        }
+
+        @Test
+        void 종료된_경매_의_최고_입찰자는_낙찰자가_되고_그_입찰가는_낙찰가가_된다() {
+            // given
+            Auction auction = withStartPrice(1L, 1L, "seq", 8000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+
+            given(auctionCacheService.findCurrentPrice(anyString())).willReturn(10000L);
+            given(auctionCacheService.findParticipants("seq"))
+                    .willReturn(List.of(2L, 3L, 4L));
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            scheduledAuctionService.handleExpiration(1L, "seq", 8000L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getWinnerId()).isEqualTo(2L);
+                softly.assertThat(auction.getWinPrice()).isEqualTo(10000L);
+                softly.assertThat(auction.getDoneAt()).isEqualTo(auction.getExpiresAt());
+                softly.assertThat(auction.getStatus()).isEqualTo(DONE);
+            });
+        }
+
+        @Test
+        void 종료된_경매_의_낙찰자의_inbox에는_낙찰_메시지가_저장된다() {
+            // given
+            Auction auction = withStartPrice(1L, 1L, "seq", 8000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+
+            given(auctionCacheService.findCurrentPrice(anyString())).willReturn(10000L);
+            given(auctionCacheService.findParticipants("seq"))
+                    .willReturn(List.of(2L, 3L, 4L));
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            String expectedMessage = CreateMessageRequest.forWinner(2L, "seq")
+                    .getMessage();
+
+            // when
+            scheduledAuctionService.handleExpiration(1L, "seq", 8000L);
+
+            // then
+            ArgumentCaptor<CreateMessageRequest> captor = ArgumentCaptor.forClass(CreateMessageRequest.class);
+            verify(inboxService, times(1)).addSingleMessage(captor.capture());
+            assertThat(captor.getValue().getMessage()).isEqualTo(expectedMessage);
+        }
+
+        @Test
+        void 종료된_경매_의_참가자의_inbox에는_결과_메시지가_저장된다() {
+            // given
+            Auction auction = withStartPrice(1L, 1L, "seq", 8000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+
+            given(auctionCacheService.findCurrentPrice(anyString())).willReturn(10000L);
+            given(auctionCacheService.findParticipants("seq"))
+                    .willReturn(List.of(2L, 3L, 4L));
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            String expectedMessage = CreateMessageRequest.forParticipants(2L, "seq")
+                    .getMessage();
+
+            // when
+            scheduledAuctionService.handleExpiration(1L, "seq", 8000L);
+
+            // then
+            ArgumentCaptor<List<CreateMessageRequest>> captor = ArgumentCaptor.forClass(List.class);
+            verify(inboxService, times(1)).addMultipleMessages(captor.capture());
+            assertThat(captor.getValue()).allSatisfy(r -> {
+                r.getMessage().equals(expectedMessage);
+            });
+        }
+
+        @Test
+        void 즉시_구매_시_구매자의_inbox에는_낙찰_메시지가_저장된다() {
+            // given
+            Auction auction = withIsBuyNow(1L, 1L, "seq", true, 60000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+            auction.finalize(2L, 60000L, auction.getExpiresAt().minusHours(2));
+
+            String expectedMessage = CreateMessageRequest.forWinner(2L, "seq")
+                    .getMessage();
+
+            BuyNowEvent buyNowEvent = BuyNowEvent.fromAuction(auction);
+
+            // when
+            scheduledAuctionService.processBuyNowMessaging(buyNowEvent);
+
+            // then
+            ArgumentCaptor<CreateMessageRequest> captor = ArgumentCaptor.forClass(CreateMessageRequest.class);
+            verify(inboxService, times(1)).addSingleMessage(captor.capture());
+            assertThat(captor.getValue().getMessage()).isEqualTo(expectedMessage);
+        }
+
+        @Test
+        void 즉시_구매_시_참가자의_inbox에는_결과_메시지가_저장된다() {
+            // given
+            Auction auction = withIsBuyNow(1L, 1L, "seq", true, 60000L);
+            ReflectionTestUtils.setField(auction, "id", 1L);
+            auction.open();
+            auction.finalize(2L, 60000L, auction.getExpiresAt().minusHours(2));
+
+            BuyNowEvent buyNowEvent = BuyNowEvent.fromAuction(auction);
+            String expectedMessage = CreateMessageRequest.forParticipants(2L, "seq")
+                    .getMessage();
+
+            given(auctionCacheService.findParticipants("seq"))
+                    .willReturn(List.of(3L, 4L));
+
+            // when
+            scheduledAuctionService.processBuyNowMessaging(buyNowEvent);
+
+            // then
+            ArgumentCaptor<List<CreateMessageRequest>> captor = ArgumentCaptor.forClass(List.class);
+            verify(inboxService, times(1)).addMultipleMessages(captor.capture());
+            assertThat(captor.getValue()).allSatisfy(r -> {
+                r.getMessage().equals(expectedMessage);
+            });
+        }
     }
 }

--- a/src/test/java/com/fifteen/auction/domain/auction/AuctionEventTest.java
+++ b/src/test/java/com/fifteen/auction/domain/auction/AuctionEventTest.java
@@ -1,0 +1,120 @@
+package com.fifteen.auction.domain.auction;
+
+import com.fifteen.auction.domain.auction.dto.event.BidProcessEvent;
+import com.fifteen.auction.domain.auction.entity.Auction;
+import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
+import com.fifteen.auction.domain.auction.service.AuctionCacheService;
+import com.fifteen.auction.domain.auction.service.BidWorkerService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.fifteen.auction.fixtures.AuctionFixture.withIsAutoExtensible;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AuctionEventTest {
+
+    @Nested
+    class 입찰_이벤트 {
+
+        @Mock AuctionRepository auctionRepository;
+        @Mock AuctionCacheService auctionCacheService;
+
+        @InjectMocks BidWorkerService bidWorkerService;
+
+        @Test
+        void 입찰_이벤트_처리_중_저동_연장이_설정된_경매만_연장_처리가_된다() {
+            // given
+            LocalDateTime originalExpiresAt = LocalDateTime.now().plusHours(2L);
+            Auction auction = withIsAutoExtensible(
+                    1L, 1L, "seq", false, originalExpiresAt);
+            BidProcessEvent event = new BidProcessEvent(
+                    "seq", 2L, 2000L, auction.getExpiresAt().minusSeconds(59));
+
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            bidWorkerService.handleBidProcess(event);
+
+            // then
+            assertThat(auction.getExpiresAt()).isEqualTo(originalExpiresAt);
+        }
+
+        @Test
+        void 입찰_이벤트_처리_중_입찰_시각이_자동_연장_경매의_마감까지_1분_이내_남았다면_3분_연장된다() {
+            // given
+            LocalDateTime originalExpiresAt = LocalDateTime.now().plusHours(2L);
+            Auction auction = withIsAutoExtensible(
+                    1L, 1L, "seq", true, originalExpiresAt);
+            BidProcessEvent event = new BidProcessEvent(
+                    "seq", 2L, 2000L, auction.getExpiresAt().minusSeconds(59));
+
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            bidWorkerService.handleBidProcess(event);
+
+            // then
+            assertThat(auction.getExpiresAt()).isEqualTo(originalExpiresAt.plusMinutes(3));
+        }
+
+        @Test
+        void 입찰_이벤트_가_처리될_때_자동_연장_경매는_한_번만_연장이_가능하다() {
+            // given
+            LocalDateTime originalExpiresAt = LocalDateTime.now().plusHours(2L);
+            Auction auction = withIsAutoExtensible(
+                    1L, 1L, "seq", true, originalExpiresAt);
+
+            BidProcessEvent event1 = new BidProcessEvent(
+                    "seq", 2L, 2000L, auction.getExpiresAt().minusSeconds(59));
+            BidProcessEvent event2 = new BidProcessEvent(
+                    "seq", 3L, 4000L, auction.getExpiresAt().minusSeconds(30));
+
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            bidWorkerService.handleBidProcess(event1);
+            bidWorkerService.handleBidProcess(event2);
+
+            // then
+            assertThat(auction.getExpiresAt()).isEqualTo(originalExpiresAt.plusMinutes(3));
+        }
+
+        @Test
+        void 입찰_이벤트_가_처리되면_경매_현재가가_최신화_된다() {
+            // given
+            LocalDateTime originalExpiresAt = LocalDateTime.now().plusHours(2L);
+            Auction auction = withIsAutoExtensible(
+                    1L, 1L, "seq", true, originalExpiresAt);
+
+            BidProcessEvent event = new BidProcessEvent(
+                    "seq", 2L, 2000L, auction.getExpiresAt().minusSeconds(59));
+
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            bidWorkerService.handleBidProcess(event);
+
+            // then
+            verify(auctionCacheService, times(1))
+                    .addNewHighPrice(eq("seq"), eq(2L), eq(2000L));
+        }
+
+    }
+}

--- a/src/test/java/com/fifteen/auction/domain/auction/AuctionTest.java
+++ b/src/test/java/com/fifteen/auction/domain/auction/AuctionTest.java
@@ -1,0 +1,363 @@
+package com.fifteen.auction.domain.auction;
+
+import com.fifteen.auction.domain.auction.dto.event.AuctionOpenEvent;
+import com.fifteen.auction.domain.auction.dto.request.AuctionCreateRequest;
+import com.fifteen.auction.domain.auction.dto.request.AuctionUpdateRequest;
+import com.fifteen.auction.domain.auction.dto.response.AuctionLog;
+import com.fifteen.auction.domain.auction.entity.Auction;
+import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
+import com.fifteen.auction.domain.auction.repository.bid.BidRepository;
+import com.fifteen.auction.domain.auction.service.AuctionCacheService;
+import com.fifteen.auction.domain.auction.service.AuctionService;
+import com.fifteen.auction.domain.auction.util.AuctionSeqGenerator;
+import com.fifteen.auction.domain.auction.util.ClockHolder;
+import com.fifteen.auction.domain.product.entity.Product;
+import com.fifteen.auction.domain.product.repository.ProductRepository;
+import com.fifteen.auction.domain.product.service.MarketPriceService;
+import com.fifteen.auction.fixtures.ProductFixture;
+import com.fifteen.auction.global.dto.PageCond;
+import com.fifteen.auction.global.dto.error.ErrorCode;
+import com.fifteen.auction.global.dto.exception.ClientException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.fifteen.auction.domain.auction.entity.AuctionStatus.CANCELED;
+import static com.fifteen.auction.domain.auction.entity.AuctionStatus.OPEN;
+import static com.fifteen.auction.fixtures.AuctionFixture.defaultAuction;
+import static com.fifteen.auction.fixtures.AuctionFixture.fromCreateDto;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AuctionTest {
+
+    public static final String ERROR_CODE_ENUM_NAME = "errorCode";
+    @Mock ProductRepository productRepository;
+    @Mock AuctionRepository auctionRepository;
+    @Mock BidRepository bidRepository;
+
+    @Mock MarketPriceService marketPriceService;
+    @Mock AuctionCacheService auctionCacheService;
+
+    @Mock ApplicationEventPublisher applicationEventPublisher;
+    @Mock AuctionSeqGenerator auctionSeqGenerator;
+    @Mock ClockHolder clockHolder;
+
+    @InjectMocks AuctionService auctionService;
+
+
+    @Nested
+    class 경매_생성 {
+        @Test
+        void 경매_생성_이_성공적으로_이뤄진다() {
+            // given
+            Product product = ProductFixture.ofUser(1L, 1L);
+            AuctionCreateRequest dto = new AuctionCreateRequest(
+                    1L,
+                    10000L,
+                    100000L,
+                    1000,
+                    true,
+                    true,
+                    LocalDateTime.now().plusHours(2)
+            );
+
+            given(productRepository.findByIdWithSeller(anyLong())).willReturn(Optional.of(product));
+            given(auctionSeqGenerator.generate(any(LocalDate.class))).willReturn("auctionSeq");
+            given(auctionRepository.save(any(Auction.class)))
+                    .willReturn(fromCreateDto(dto, 1L, "auctionSeq"));
+
+            // when
+            String auctionSeq = auctionService.create(dto, 1L);
+
+            // then
+            assertThat(auctionSeq).isEqualTo("auctionSeq");
+        }
+
+        @Test
+        void 경매_생성_중_자신이_등록한_상품이_아니면_예외가_발생한다() {
+            // given
+            Product product = ProductFixture.ofUser(1L, 1L);
+            AuctionCreateRequest dto = new AuctionCreateRequest(
+                    1L,
+                    10000L,
+                    100000L,
+                    1000,
+                    true,
+                    true,
+                    LocalDateTime.now().plusHours(2)
+            );
+
+            given(productRepository.findByIdWithSeller(anyLong())).willReturn(Optional.of(product));
+
+            // when & then
+            assertThatThrownBy(() -> auctionService.create(dto, 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.NOT_OWNING_PRODUCT);
+        }
+    }
+
+    @Nested
+    class 경매_조회 {
+        @Test
+        void 경매_단건_조회_는_조회수를_증가시킨다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            given(auctionRepository.findOpenOneByAuctionSeq(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            auctionService.findOneAndIncreaseView("seq");
+
+            // then
+            assertThat(auction.getViews()).isEqualTo(1);
+        }
+
+        @Test
+        void 경매_내역_조회_에서_진행중인_경매는_현재_가격과_종료_예정_시각을_포함한다() {
+            // given
+            Auction openAuction = defaultAuction(1L, 1L, "seq");
+            openAuction.open();
+
+            given(bidRepository.findJoinedAuction(any(Pageable.class), anyLong()))
+                    .willReturn(new PageImpl<>(List.of(openAuction)));
+            given(auctionCacheService.findCurrentPrice(anyString()))
+                    .willReturn(1000L);
+
+            // when
+            List<AuctionLog> results = auctionService.findJoinedAuction(
+                    new PageCond(1, 10), 2L
+            ).getContent();
+
+            // then
+            assertThat(results).allSatisfy(r -> {
+                assertThat(r.getPrice()).isEqualTo(1000L);
+                assertThat(r.getExpiredTime()).isEqualTo(openAuction.getExpiresAt());
+                assertThat(r.getIsWinner()).isEqualTo(false);
+            });
+        }
+
+        @Test
+        void 경매_내역_조회_에서_유찰된_경매는_시작_가격과_종료_시각을_포함한다() {
+            // given
+            Auction miscarryAuction = defaultAuction(1L, 1L, "seq");
+            miscarryAuction.open();
+            miscarryAuction.misCarry();
+
+            given(bidRepository.findJoinedAuction(any(Pageable.class), anyLong()))
+                    .willReturn(new PageImpl<>(List.of(miscarryAuction)));
+
+            // when
+            List<AuctionLog> results = auctionService.findJoinedAuction(
+                    new PageCond(1, 10), 2L
+            ).getContent();
+
+            // then
+            assertThat(results).allSatisfy(r -> {
+                assertThat(r.getPrice()).isEqualTo(miscarryAuction.getStartPrice());
+                assertThat(r.getExpiredTime()).isEqualTo(miscarryAuction.getExpiresAt());
+                assertThat(r.getIsWinner()).isEqualTo(false);
+            });
+        }
+
+        @Test
+        void 경매_내역_조회_에서_완료된_경매는_낙찰_가격과_종료_시각을_포함한다() {
+            // given
+            LocalDateTime doneAt = LocalDateTime.now();
+
+            Auction doneAuction = defaultAuction(1L, 1L, "seq");
+            doneAuction.open();
+            doneAuction.finalize(2L, 10000L, doneAt);
+
+            given(bidRepository.findJoinedAuction(any(Pageable.class), anyLong()))
+                    .willReturn(new PageImpl<>(List.of(doneAuction)));
+
+            // when
+            List<AuctionLog> results = auctionService.findJoinedAuction(
+                    new PageCond(1, 10), 2L
+            ).getContent();
+
+            // then
+            assertThat(results).allSatisfy(r -> {
+                assertThat(r.getPrice()).isEqualTo(10000L);
+                assertThat(r.getExpiredTime()).isEqualTo(doneAt);
+            });
+        }
+    }
+
+    @Nested
+    class 경매_변경 {
+        @Test
+        void 경매_취소_를_공개_전_상태가_아닌데_시도하면_예외가_발생한다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when & then
+            assertThatThrownBy(() -> auctionService.cancel("seq", 1L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.CLOSE_NOT_PENDING);
+
+        }
+
+        @Test
+        void 경매_취소_가_성공하면_취소_상태가_되고_취소_시각이_기록된다() {
+            // given
+            LocalDateTime canceledAt = LocalDateTime.now();
+            Auction auction = defaultAuction(1L, 1L, "seq");
+
+            given(clockHolder.now()).willReturn(canceledAt);
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+            // when
+            auctionService.cancel("seq", 1L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getStatus()).isEqualTo(CANCELED);
+                softly.assertThat(auction.getDoneAt()).isEqualTo(canceledAt);
+            });
+        }
+
+        @Test
+        void 경매_공개_를_공개_전_상태가_아닌데_시도하면_예외가_발생한다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when & then
+            assertThatThrownBy(() -> auctionService.open("seq", 1L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.AUCTION_ALREADY_OPEN);
+        }
+
+        @Test
+        void 경매_공개_가_성공하면_공개_상태가_된다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            auctionService.open("seq", 1L);
+
+            // then
+            assertThat(auction.getStatus()).isEqualTo(OPEN);
+        }
+
+        @Test
+        void 경매_공개_가_성공하면_공개_이벤트를_발행한다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            auctionService.open("seq", 1L);
+
+            // then
+            ArgumentCaptor<AuctionOpenEvent> captor = ArgumentCaptor.forClass(AuctionOpenEvent.class);
+            verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+            assertSoftly(softly -> {
+                AuctionOpenEvent event = captor.getValue();
+                softly.assertThat(event.getAuctionSeq()).isEqualTo("seq");
+                softly.assertThat(event.getStartPrice()).isEqualTo(auction.getStartPrice());
+                softly.assertThat(event.getExpiresAt()).isEqualTo(auction.getExpiresAt());
+            });
+        }
+
+        @Test
+        void 경매_정보_변경_이_성공적으로_이뤄진다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            LocalDateTime newExpiresAt = LocalDateTime.now();
+
+            AuctionUpdateRequest request = new AuctionUpdateRequest(
+                    500L,
+                    500L,
+                    500,
+                    false,
+                    false,
+                    newExpiresAt
+            );
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when
+            auctionService.updateInfo("seq", 1L, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getStartPrice()).isEqualTo(500L);
+                softly.assertThat(auction.getBuyNowPrice()).isEqualTo(500L);
+                softly.assertThat(auction.getBidUnit()).isEqualTo(500);
+                softly.assertThat(auction.isBuyNowSet()).isFalse();
+                softly.assertThat(auction.isAutoExtensible()).isFalse();
+                softly.assertThat(auction.getExpiresAt()).isEqualTo(newExpiresAt);
+
+            });
+        }
+
+        @Test
+        void 경매_정보_변경_을_공개_전_상태가_아닌데_시도하면_예외가_발생한다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            LocalDateTime newExpiresAt = LocalDateTime.now();
+
+            AuctionUpdateRequest request = new AuctionUpdateRequest(
+                    500L,
+                    500L,
+                    500,
+                    false,
+                    false,
+                    newExpiresAt
+            );
+
+            given(auctionRepository.findOneBySeqAndSellerId(anyString(), anyLong()))
+                    .willReturn(Optional.of(auction));
+
+            // when & then
+            assertThatThrownBy(() -> auctionService.updateInfo("seq", 1L, request))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.AUCTION_ALREADY_OPEN);
+
+        }
+
+    }
+}

--- a/src/test/java/com/fifteen/auction/domain/auction/BidTest.java
+++ b/src/test/java/com/fifteen/auction/domain/auction/BidTest.java
@@ -1,0 +1,373 @@
+package com.fifteen.auction.domain.auction;
+
+import com.fifteen.auction.domain.auction.dto.event.BidProcessEvent;
+import com.fifteen.auction.domain.auction.dto.event.BuyNowEvent;
+import com.fifteen.auction.domain.auction.dto.request.BidRequest;
+import com.fifteen.auction.domain.auction.dto.response.BidHistoryInfo;
+import com.fifteen.auction.domain.auction.entity.Auction;
+import com.fifteen.auction.domain.auction.repository.auction.AuctionRepository;
+import com.fifteen.auction.domain.auction.repository.bid.BidRepository;
+import com.fifteen.auction.domain.auction.service.AuctionCacheService;
+import com.fifteen.auction.domain.auction.service.BidService;
+import com.fifteen.auction.domain.auction.util.ClockHolder;
+import com.fifteen.auction.global.dto.PageCond;
+import com.fifteen.auction.global.dto.error.ErrorCode;
+import com.fifteen.auction.global.dto.exception.ClientException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.fifteen.auction.domain.auction.entity.AuctionStatus.DONE;
+import static com.fifteen.auction.fixtures.AuctionFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class BidTest {
+
+    @Mock AuctionRepository auctionRepository;
+    @Mock AuctionCacheService auctionCacheService;
+    @Mock BidRepository bidRepository;
+
+    @Mock ClockHolder clockHolder;
+    @Mock ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks BidService bidService;
+
+    public static final String ERROR_CODE_ENUM_NAME = "errorCode";
+
+    @Nested
+    class 입찰 {
+        @Test
+        void 입찰_은_공개된_경매에만_요청이_가능하다() {
+            // given
+            BidRequest bidRequest = new BidRequest(8000L);
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> bidService.bid("seq", 1L, bidRequest))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.AUCTION_NOT_FOUND);
+        }
+
+        @Test
+        void 입찰_은_자신이_생성한_경매에는_요청할_수_없다() {
+            // given
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            BidRequest request = new BidRequest(8000L);
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.bid("seq", 1L, request))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.INVALID_BID_REQUEST);
+        }
+
+        @Test
+        void 입찰_은_마감시각이_지난_이후에는_요청할_수_없다() {
+            // given
+            BidRequest request = new BidRequest(8000L);
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().plusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.bid("seq", 1L, request))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.INVALID_BID_REQUEST);
+        }
+
+        @Test
+        void 입찰_은_현재_가격보다_높은_가격에서만_이루질_수_있다() {
+            // given
+            BidRequest request = new BidRequest(8000L);
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+            given(auctionCacheService.isBidUnderPrice(anyString(), anyLong(), anyInt()))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> bidService.bid("seq", 2L, request))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.LOW_BID_PRICE);
+        }
+
+        @Test
+        void 입찰_이_완료_되면_입찰_처리_이벤트가_발행된다() {
+            // given
+            BidRequest request = new BidRequest(8000L);
+            Auction auction = defaultAuction(1L, 1L, "seq");
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+            given(auctionCacheService.isBidUnderPrice(anyString(), anyLong(), anyInt()))
+                    .willReturn(false);
+
+            // when
+            bidService.bid("seq", 2L, request);
+
+            // then
+            ArgumentCaptor<BidProcessEvent> captor = ArgumentCaptor.forClass(BidProcessEvent.class);
+            verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+            assertSoftly(softly -> {
+                BidProcessEvent event = captor.getValue();
+                softly.assertThat(event.getBidderId()).isEqualTo(2L);
+                softly.assertThat(event.getBidPrice()).isEqualTo(8000L);
+                softly.assertThat(event.getAuctionSeq()).isEqualTo("seq");
+                softly.assertThat(event.getBidAt()).isEqualTo(auction.getExpiresAt().minusHours(1));
+            });
+
+        }
+    }
+
+    @Nested
+    class 즉시_구매 {
+
+        @Test
+        void 즉시_구매_는_공개된_경매에만_요청이_가능하다() {
+            // given
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.AUCTION_NOT_FOUND);
+        }
+
+        @Test
+        void 즉시_구매_는_즉시_구매_가_활성화_된_경매에만_요청이_가능하다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", false, null);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.CANNOT_BUY_NOW);
+        }
+
+        @Test
+        void 즉시_구매_는_자신이_생성한_경매에는_요청할_수_없다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 1L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.INVALID_BUY_NOW_REQUEST);
+        }
+
+        @Test
+        void 즉시_구매_는_마감시각이_지난_이후에는_요청할_수_없다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().plusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.INVALID_BUY_NOW_REQUEST);
+        }
+
+        @Test
+        void 즉시_구매_마감처리는_공개_상태인_경매만_가능하다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.FINALIZE_ALREADY_DONE);
+        }
+
+        @Test
+        void 즉시_구매_마감처리는_종료된_적이_없는_경매만_가능하다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+            auction.finalize(2L, 8000L, auction.getExpiresAt());
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when & then
+            assertThatThrownBy(() -> bidService.buyNow("seq", 2L))
+                    .isInstanceOf(ClientException.class)
+                    .extracting(ERROR_CODE_ENUM_NAME)
+                    .isEqualTo(ErrorCode.FINALIZE_ALREADY_DONE);
+        }
+
+        @Test
+        void 즉시_구매_처리가_되면_낙찰_유저의_id와_낙찰가가_기록된다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when
+            bidService.buyNow("seq", 2L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getWinnerId()).isEqualTo(2L);
+                softly.assertThat(auction.getWinPrice()).isEqualTo(8000L);
+            });
+        }
+
+        @Test
+        void 즉시_구매_처리가_되면_종료_시각을_기록하고_완료_상태로_변경한다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when
+            bidService.buyNow("seq", 2L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(auction.getDoneAt()).isEqualTo(auction.getExpiresAt().minusHours(1));
+                softly.assertThat(auction.getStatus()).isEqualTo(DONE);
+            });
+        }
+
+        @Test
+        void 즉시_구매_처리가_되면_즉시_구매_이벤트를_발행한다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            given(auctionRepository.findOpenOneBySeqWithSeller(anyString()))
+                    .willReturn(Optional.of(auction));
+            given(clockHolder.now())
+                    .willReturn(auction.getExpiresAt().minusHours(1));
+
+            // when
+            bidService.buyNow("seq", 2L);
+
+            // then
+            ArgumentCaptor<BuyNowEvent> captor = ArgumentCaptor.forClass(BuyNowEvent.class);
+            verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+            assertSoftly(softly -> {
+                BuyNowEvent event = captor.getValue();
+                softly.assertThat(event.getAuctionSeq()).isEqualTo("seq");
+                softly.assertThat(event.getWinnerId()).isEqualTo(2L);
+                softly.assertThat(event.getBuyNowPrice()).isEqualTo(8000L);
+                softly.assertThat(event.getBuyAt()).isEqualTo(auction.getExpiresAt().minusHours(1));
+            });
+        }
+    }
+
+    @Nested
+    class 경매_기록_조회 {
+        @Test
+        void 경매_기록_조회가_경매_진행_중에_이루어지면_입찰_가격이_별표_처리된다() {
+            // given
+            Auction auction = withIsBuyNow(
+                    1L, 1L, "seq", true, 8000L);
+            auction.open();
+
+            List<BidHistoryInfo> resultContent = List.of(
+                    BidHistoryInfo.forProgress(defaultBid(auction, 2L, 8000L)),
+                    BidHistoryInfo.forProgress(defaultBid(auction, 3L, 10000L))
+            );
+
+            given(bidRepository.findAllInProgressByAuctionSeq(any(Pageable.class), anyString()))
+                    .willReturn(new PageImpl<>(resultContent));
+
+            // when
+            List<BidHistoryInfo> results = bidService
+                    .bidHistoriesInProgress("seq", new PageCond(1, 10))
+                    .getContent();
+
+            // then
+            assertThat(results).allSatisfy(r -> {
+                assertThat(r.getBidPrice()).isEqualTo("***");
+            });
+        }
+    }
+}

--- a/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
@@ -2,6 +2,7 @@ package com.fifteen.auction.fixtures;
 
 import com.fifteen.auction.domain.auction.dto.request.AuctionCreateRequest;
 import com.fifteen.auction.domain.auction.entity.Auction;
+import com.fifteen.auction.domain.auction.entity.Bid;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -23,7 +24,7 @@ public class AuctionFixture {
     }
 
     public static Auction defaultAuction(Long productId, Long ownerId, String auctionSeq) {
-        Auction auction = new Auction(
+        return new Auction(
                 ProductFixture.ofUser(productId, ownerId),
                 auctionSeq,
                 1000L,
@@ -33,6 +34,29 @@ public class AuctionFixture {
                 true,
                 LocalDateTime.now().plusHours(2)
         );
-        return auction;
+    }
+
+    public static Auction withIsBuyNow(
+            Long productId, Long ownerId, String auctionSeq, boolean isBuyNow, Long buyNowPrice
+    ) {
+        return new Auction(
+                ProductFixture.ofUser(productId, ownerId),
+                auctionSeq,
+                1000L,
+                buyNowPrice,
+                1000,
+                isBuyNow,
+                true,
+                LocalDateTime.now().plusHours(2)
+        );
+    }
+
+    public static Bid defaultBid(Auction auc, Long bidderId, Long bidPrice) {
+        return new Bid(
+                auc,
+                bidderId,
+                bidPrice,
+                auc.getExpiresAt().minusMinutes(30)
+        );
     }
 }

--- a/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
@@ -66,6 +66,19 @@ public class AuctionFixture {
         );
     }
 
+    public static Auction withStartPrice(Long productId, Long ownerId, String auctionSeq, Long startPrice) {
+        return new Auction(
+                ProductFixture.ofUser(productId, ownerId),
+                auctionSeq,
+                startPrice,
+                10000L,
+                1000,
+                true,
+                true,
+                LocalDateTime.now().plusHours(2)
+        );
+    }
+
     public static Bid defaultBid(Auction auc, Long bidderId, Long bidPrice) {
         return new Bid(
                 auc,

--- a/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
@@ -51,6 +51,21 @@ public class AuctionFixture {
         );
     }
 
+    public static Auction withIsAutoExtensible(
+            Long productId, Long ownerId, String auctionSeq, boolean isAutoExtensible, LocalDateTime expiresAt
+    ) {
+        return new Auction(
+                ProductFixture.ofUser(productId, ownerId),
+                auctionSeq,
+                1000L,
+                50000L,
+                1000,
+                true,
+                isAutoExtensible,
+                expiresAt
+        );
+    }
+
     public static Bid defaultBid(Auction auc, Long bidderId, Long bidPrice) {
         return new Bid(
                 auc,

--- a/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/AuctionFixture.java
@@ -1,0 +1,38 @@
+package com.fifteen.auction.fixtures;
+
+import com.fifteen.auction.domain.auction.dto.request.AuctionCreateRequest;
+import com.fifteen.auction.domain.auction.entity.Auction;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuctionFixture {
+    public static Auction fromCreateDto(AuctionCreateRequest req, Long ownerId, String auctionSeq) {
+        return new Auction(
+                ProductFixture.ofUser(req.getProductId(), ownerId),
+                auctionSeq,
+                req.getStartPrice(),
+                req.getBuyNowPrice(),
+                req.getBidUnit(),
+                req.getIsBuyNowSet(),
+                req.getIsAutoExtensible(),
+                req.getExpiresAt()
+        );
+    }
+
+    public static Auction defaultAuction(Long productId, Long ownerId, String auctionSeq) {
+        Auction auction = new Auction(
+                ProductFixture.ofUser(productId, ownerId),
+                auctionSeq,
+                1000L,
+                10000L,
+                1000,
+                true,
+                true,
+                LocalDateTime.now().plusHours(2)
+        );
+        return auction;
+    }
+}

--- a/src/test/java/com/fifteen/auction/fixtures/ProductFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/ProductFixture.java
@@ -1,0 +1,22 @@
+package com.fifteen.auction.fixtures;
+
+import com.fifteen.auction.domain.product.entity.Product;
+import com.fifteen.auction.domain.product.entity.ProductCategory;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductFixture {
+    public static Product ofUser(Long productId, Long userId) {
+        Product product = Product.create(
+                UserFixture.createDefaultSeller(userId),
+                ProductCategory.create("category", null),
+                "product",
+                "good product, man"
+        );
+        ReflectionTestUtils.setField(product, "id", productId
+        );
+        return product;
+    }
+}

--- a/src/test/java/com/fifteen/auction/fixtures/UserFixture.java
+++ b/src/test/java/com/fifteen/auction/fixtures/UserFixture.java
@@ -1,0 +1,29 @@
+package com.fifteen.auction.fixtures;
+
+import com.fifteen.auction.domain.user.entity.User;
+import com.fifteen.auction.domain.user.enums.UserRole;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserFixture {
+    public static User createDefaultSeller(Long userId) {
+        User user = new User(
+                "seller@example.com",
+                "sellery",
+                "seller",
+                "male",
+                "20-29",
+                "1234",
+                "address",
+                "010-1234-5678",
+                "electronics",
+                "001-1133-111131",
+                null,
+                UserRole.ROLE_USER
+        );
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}


### PR DESCRIPTION
## 변경 사항
- Test Fixture 팩토리 메서드 추가
- 경매 생성, 조회, 수정 케이스에 대한 테스트 시나리오 추가
- LocalDateTime.now()를 테스트하기 쉬운 구조로 변경
- 테스트 과정에서 발견한 AuctionService.updateInfo 정보 누락 해결

---
2025.04.23 11:00 추가
- Bid 관련 Fixture 추가
- BidService LocalDateTime.now() 변경된 구조 반영
- BidService.buyNow()에서 isBuyNowSet을 검증하는 로직 추가

---
2025.04.23 19:53 추가
- Auction, Bid 이벤트 처리 메서드 테스트 시나리오 추가
- Runnable, 기술 종속성 등, 테스트 하기 쉬운 형태로 리팩토링